### PR TITLE
fix: validate link URL schemes

### DIFF
--- a/src/lib/__tests__/link-url.test.ts
+++ b/src/lib/__tests__/link-url.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { isAllowedLinkUrl } from "@/lib/link-url";
+
+describe("isAllowedLinkUrl", () => {
+  it("allows regular http and https links", () => {
+    expect(isAllowedLinkUrl("url", "https://example.com")).toBe(true);
+    expect(isAllowedLinkUrl("url", "http://example.com")).toBe(true);
+  });
+
+  it("blocks executable schemes for regular links", () => {
+    expect(isAllowedLinkUrl("url", "javascript:alert(1)")).toBe(false);
+    expect(isAllowedLinkUrl("url", "data:text/html,<script>alert(1)</script>")).toBe(false);
+  });
+
+  it("allows each contact link type only for its expected scheme", () => {
+    expect(isAllowedLinkUrl("email", "mailto:hello@example.com")).toBe(true);
+    expect(isAllowedLinkUrl("phone", "tel:+15551234567")).toBe(true);
+    expect(isAllowedLinkUrl("sms", "sms:+15551234567")).toBe(true);
+
+    expect(isAllowedLinkUrl("email", "https://example.com")).toBe(false);
+    expect(isAllowedLinkUrl("phone", "javascript:alert(1)")).toBe(false);
+  });
+
+  it("only allows WhatsApp links through wa.me over https", () => {
+    expect(isAllowedLinkUrl("whatsapp", "https://wa.me/15551234567")).toBe(true);
+    expect(isAllowedLinkUrl("whatsapp", "whatsapp://send?phone=15551234567")).toBe(true);
+    expect(isAllowedLinkUrl("whatsapp", "http://wa.me/15551234567")).toBe(false);
+    expect(isAllowedLinkUrl("whatsapp", "https://example.com/15551234567")).toBe(false);
+  });
+
+  it("allows local file paths without protocol-relative URLs", () => {
+    expect(isAllowedLinkUrl("file", "/uploads/demo.pdf")).toBe(true);
+    expect(isAllowedLinkUrl("file", "//evil.example/file.pdf")).toBe(false);
+  });
+});

--- a/src/lib/link-url.ts
+++ b/src/lib/link-url.ts
@@ -1,0 +1,29 @@
+const ALLOWED_SCHEMES_BY_TYPE: Record<string, Set<string>> = {
+  url: new Set(["http:", "https:"]),
+  email: new Set(["mailto:"]),
+  phone: new Set(["tel:"]),
+  whatsapp: new Set(["https:", "whatsapp:"]),
+  sms: new Set(["sms:"]),
+  vcard: new Set(["https:", "http:"]),
+  file: new Set(["/", "https:", "http:"]),
+};
+
+export function isAllowedLinkUrl(type: string, value: string): boolean {
+  const trimmed = value.trim();
+  const allowedSchemes = ALLOWED_SCHEMES_BY_TYPE[type];
+  if (!allowedSchemes || !trimmed) return false;
+
+  if (trimmed.startsWith("/")) {
+    return allowedSchemes.has("/") && !trimmed.startsWith("//");
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (type === "whatsapp" && url.protocol === "https:") {
+      return url.hostname === "wa.me";
+    }
+    return allowedSchemes.has(url.protocol);
+  } catch {
+    return false;
+  }
+}

--- a/src/server/actions/links.ts
+++ b/src/server/actions/links.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { getSession } from "@/lib/auth";
 import { demoBlock } from "@/lib/demo";
+import { isAllowedLinkUrl } from "@/lib/link-url";
 import {
   createLink as createLinkQuery,
   updateLink as updateLinkQuery,
@@ -19,23 +20,28 @@ async function requireAuth(): Promise<boolean> {
   return !!session;
 }
 
-const linkSchema = z.object({
-  id: z.string().optional(),
-  title: z.string().min(1, "Title is required").max(120),
-  url: z.string().min(1, "URL is required").max(2048),
-  description: z.string().max(300).optional().nullable(),
-  type: z.enum(["url", "email", "phone", "whatsapp", "sms", "vcard", "file"]).default("url"),
-  isHighlighted: z
-    .union([z.string(), z.boolean()])
-    .transform((v) => v === true || v === "true" || v === "on")
-    .default(false),
-  isActive: z
-    .union([z.string(), z.boolean()])
-    .transform((v) => v === true || v === "true" || v === "on")
-    .default(true),
-  scheduleStart: z.string().optional().nullable(),
-  scheduleEnd: z.string().optional().nullable(),
-});
+const linkSchema = z
+  .object({
+    id: z.string().optional(),
+    title: z.string().min(1, "Title is required").max(120),
+    url: z.string().min(1, "URL is required").max(2048),
+    description: z.string().max(300).optional().nullable(),
+    type: z.enum(["url", "email", "phone", "whatsapp", "sms", "vcard", "file"]).default("url"),
+    isHighlighted: z
+      .union([z.string(), z.boolean()])
+      .transform((v) => v === true || v === "true" || v === "on")
+      .default(false),
+    isActive: z
+      .union([z.string(), z.boolean()])
+      .transform((v) => v === true || v === "true" || v === "on")
+      .default(true),
+    scheduleStart: z.string().optional().nullable(),
+    scheduleEnd: z.string().optional().nullable(),
+  })
+  .refine((link) => isAllowedLinkUrl(link.type, link.url), {
+    path: ["url"],
+    message: "URL scheme is not allowed for this link type",
+  });
 
 export async function createLink(formData: FormData): Promise<ActionResult> {
   const demo = demoBlock();


### PR DESCRIPTION
## Summary
- add server-side link URL scheme validation based on link type
- reject unsafe executable schemes such as javascript: and data:
- add Vitest coverage for allowed and rejected URL schemes

Closes #14

## Validation
- npm test
- npm run lint (passes with existing warning in src/app/(public)/[slug]/opengraph-image/route.tsx)