### PR TITLE
fix: reject unsupported backup versions

### DIFF
--- a/src/server/actions/__tests__/data.test.ts
+++ b/src/server/actions/__tests__/data.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  demoBlock: vi.fn(() => null),
+  getSession: vi.fn(async () => ({ userId: 1 })),
+  transaction: vi.fn(),
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mocks.revalidatePath,
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    transaction: mocks.transaction,
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  analyticsClicks: {},
+  analyticsPageviews: {},
+  links: {},
+  profile: {},
+  settings: {},
+  themes: {},
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getSession: mocks.getSession,
+}));
+
+vi.mock("@/lib/demo", () => ({
+  demoBlock: mocks.demoBlock,
+}));
+
+vi.mock("@/server/queries", () => ({
+  updateSetting: vi.fn(),
+}));
+
+import { restoreBackup } from "@/server/actions/data";
+
+function backupFile(payload: unknown): File {
+  return new File([JSON.stringify(payload)], "backup.json", {
+    type: "application/json",
+  });
+}
+
+describe("restoreBackup", () => {
+  it("rejects unsupported backup versions before mutating data", async () => {
+    const formData = new FormData();
+    formData.set(
+      "file",
+      backupFile({
+        version: 2,
+        exportedAt: "2026-07-03T00:00:00.000Z",
+        profile: [],
+        links: [],
+        settings: [],
+        themes: [],
+      }),
+    );
+
+    await expect(restoreBackup(formData)).resolves.toEqual({
+      success: false,
+      error: "Unsupported backup version: 2. This instance expects version 1.",
+    });
+    expect(mocks.transaction).not.toHaveBeenCalled();
+    expect(mocks.revalidatePath).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/actions/data.ts
+++ b/src/server/actions/data.ts
@@ -21,6 +21,8 @@ import {
 
 export type ActionResult = { success: true } | { success: false; error: string };
 
+const SUPPORTED_BACKUP_VERSION = 1;
+
 interface BackupPayload {
   version: number;
   exportedAt: string;
@@ -69,12 +71,20 @@ export async function restoreBackup(formData: FormData): Promise<ActionResult> {
 
   if (
     !parsed ||
+    typeof parsed.version !== "number" ||
     !Array.isArray(parsed.profile) ||
     !Array.isArray(parsed.links) ||
     !Array.isArray(parsed.settings) ||
     !Array.isArray(parsed.themes)
   ) {
     return { success: false, error: "Not a valid LinkBreeze backup" };
+  }
+
+  if (parsed.version !== SUPPORTED_BACKUP_VERSION) {
+    return {
+      success: false,
+      error: `Unsupported backup version: ${parsed.version}. This instance expects version ${SUPPORTED_BACKUP_VERSION}.`,
+    };
   }
 
   try {


### PR DESCRIPTION
## Summary
- rejects backup payloads when `version` is not the supported backup version
- treats missing/non-numeric `version` as an invalid LinkBreeze backup
- adds a restore action test proving unsupported versions return an error before any database transaction or revalidation runs

## Validation
- `git diff --check`
- `npm ci`
- `npm test -- src/server/actions/__tests__/data.test.ts`
- `npm test` (17 passed)
- `npm run lint`
- `npm run build`

Closes #16